### PR TITLE
MNT: Change the formatting of time-series data for the frontend

### DIFF
--- a/pvw/server/enlil.py
+++ b/pvw/server/enlil.py
@@ -690,11 +690,9 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
 
         Returns
         -------
-        List of data
+        JSON formatted similarly to a LaTiS-response
         """
-        # Transform the variable name from the frontend to the back
-        var = VARIABLE_MAP[variable]
-        return self.evolutions[sat].get_data(var)
+        return self.evolutions[sat].as_latis()
 
     def update(self, caller, event):
         """

--- a/pvw/server/enlil.py
+++ b/pvw/server/enlil.py
@@ -679,14 +679,12 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
         return self.evolutions[sat].get_times()
 
     @exportRpc("pv.enlil.get_satellite_data")
-    def get_satellite_data(self, sat, variable):
+    def get_satellite_data(self, sat):
         """
         Returns a time-series of data for the given satellite and variable.
 
         sat : str
             Name of the satellite (earth, stereoa, stereob)
-        variable : str
-            Variable of interest
 
         Returns
         -------

--- a/pvw/server/evolution.py
+++ b/pvw/server/evolution.py
@@ -73,7 +73,9 @@ class Evolution:
         ntimes = len(self.times)
         timestep_data = []
         for i in range(ntimes):
-            curr_row = [self.get_times()[i]]
+            # Time is in units of seconds from epoch, but Scicharts needs
+            # the units to be in milliseconds
+            curr_row = [int(self.get_times()[i]) * 1000]
             for var in ["Density", "Vr", "Pressure", "T", "Bx", "By", "Bz"]:
                 curr_row.append(self.get_data(var)[i][0])
             timestep_data.append(curr_row)
@@ -81,7 +83,7 @@ class Evolution:
         json_out = {f"{self.name}": {
             "metadata": {
                 "time": {
-                    "units": "seconds since 1970-01-01",
+                    "units": "milliseconds since 1970-01-01",
                     "length": f"{ntimes}"
                 },
                 "density": {

--- a/pvw/server/evolution.py
+++ b/pvw/server/evolution.py
@@ -65,3 +65,73 @@ class Evolution:
         List of times for this satellite
         """
         return self.json['coords']['time']['data']
+
+    def as_latis(self):
+        """Create a Latis-style return for front-end use."""
+        # List of lists
+        # (ntimes, nvariables)
+        ntimes = len(self.times)
+        timestep_data = []
+        for i in range(ntimes):
+            curr_row = [self.get_times()[i]]
+            for var in ["Density", "Vr", "Pressure", "T", "Bx", "By", "Bz"]:
+                curr_row.append(self.get_data(var)[i][0])
+            timestep_data.append(curr_row)
+
+        json_out = {f"{self.name}": {
+            "metadata": {
+                "time": {
+                    "units": "seconds since 1970-01-01",
+                    "length": f"{ntimes}"
+                },
+                "density": {
+                    "missing_value": "99999.99",
+                    "description": "Density",
+                    "units": "r<sup>2</sup>N/cm<sup>3</sup>"
+                },
+                "velocity": {
+                    "missing_value": "99999.99",
+                    "description": "Velocity",
+                    "units": "km/s"
+                },
+                "pressure": {
+                    "missing_value": "99999.99",
+                    "description": "Ram pressure",
+                    "units": ("r<sup>2</sup>N/cm<sup>3</sup> * "
+                              "km<sup>2</sup>/s<sup>2</sup>")
+                },
+                "temperature": {
+                    "missing_value": "99999.99",
+                    "description": "Temperature",
+                    "units": "K"
+                },
+                "bx": {
+                    "missing_value": "99999.99",
+                    "description": "BX",
+                    "units": "nT"
+                },
+                "by": {
+                    "missing_value": "99999.99",
+                    "description": "BX",
+                    "units": "nT"
+                },
+                "bz": {
+                    "missing_value": "99999.99",
+                    "description": "BX",
+                    "units": "nT"
+                }
+            },
+            "parameters": [
+                "time",
+                "density",
+                "velocity",
+                "pressure",
+                "temperature",
+                "bx",
+                "by",
+                "bz"
+            ],
+            "data": timestep_data
+            }
+        }
+        return json.dumps(json_out)


### PR DESCRIPTION
This updates the response to be JSON and Latis-like. Corresponding to the discussion in SWT-249.