### PR TITLE
Add ability to select a run

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ pip install wslink
 Now, you can run the server with
 
 ```bash
-pvpython pvw/server/pv_server_statefile.py --port 1234 --file /path/to/pv-data-3d.nc
+pvpython pvw/server/pv_server_statefile.py --port 1234 --dir /path/to/<pv-data-3d.nc>
 ```
 
 where the port is `1234` for local development, and the path to the input file is
-given to the `--file` command line argument.
+given to the `--dir` command line argument.

--- a/pvw/launcher/config.json
+++ b/pvw/launcher/config.json
@@ -37,7 +37,7 @@
         "/pvw/server/pv_server_statefile.py",
         "--port", "${port}",
         "--authKey", "${secret}",
-        "--file", "/data/pv-data-3d.nc",
+        "--dir", "/data",
         "--viewport-max-width", "1920",
         "--viewport-max-height", "1080",
         "--timeout", "30"

--- a/pvw/server/enlil.py
+++ b/pvw/server/enlil.py
@@ -59,7 +59,7 @@ SATELLITE_COLORS = {"earth": [0.0, 0.3333333333333333, 0.0],
 
 
 class EnlilDataset(pv_protocols.ParaViewWebProtocol):
-    def __init__(self, fname):
+    def __init__(self, dirname):
         """
         Enlil 4D dataset representation in Paraview.
 
@@ -70,9 +70,10 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
         # Initialize the PV web protocols
         super().__init__()
         # Save the data directory
-        self._data_dir = os.path.join(os.path.dirname(fname))
-        self.evolutions = {x.name: x for x in load_evolution_files(fname)}
-        # create a new 'NetCDF Reader'
+        self._data_dir = dirname
+        self.evolutions = {x.name: x for x in load_evolution_files(dirname)}
+        # create a new 'NetCDF Reader' from the full data path
+        fname = os.path.join(dirname, "pv-data-3d.nc")
         self.data = pvs.NetCDFReader(
             registrationName='enlil-data', FileName=[fname])
         self.data.Dimensions = '(longitude, latitude, radius)'
@@ -945,19 +946,18 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
         self.earth_translation2.Transform.Translate = earth_pos
 
 
-def load_evolution_files(fname):
+def load_evolution_files(dirname):
     """
     Loads evolution files relative to the given file.
 
-    fname : str
-        File name of the full 4D file. The evolution files
-        should all be in the same directory as this.
+    dirname : str
+        Directory path for the evolution files.
 
     Returns
     -------
     A list of Evolution objects.
     """
     # Find all json files in our current directory
-    files = glob.glob(os.path.join(os.path.dirname(fname), '*.json'))
+    files = glob.glob(os.path.join(dirname, '*.json'))
     # Iterate over the files and create an Evolution object for each one
     return [Evolution(f) for f in files]

--- a/pvw/server/pv_server_statefile.py
+++ b/pvw/server/pv_server_statefile.py
@@ -23,9 +23,9 @@ class _DemoServer(pv_wslink.PVServerProtocol):
 
     @staticmethod
     def add_arguments(parser):
-        parser.add_argument("--file", default="/data/pv-data-3d.nc",
+        parser.add_argument("--dir", default="/data",
                             help=("Path to the NetCDF file to load"),
-                            dest="data_file")
+                            dest="data_dir")
         parser.add_argument("--viewport-scale", default=1.0, type=float,
                             help="Viewport scaling factor",
                             dest="viewportScale")
@@ -44,7 +44,7 @@ class _DemoServer(pv_wslink.PVServerProtocol):
     def configure(args):
         # Update this server based on the passed in arguments
         _DemoServer.authKey = args.authKey
-        _DemoServer.data_file = args.data_file
+        _DemoServer.data_dir = args.data_dir
         _DemoServer.viewportScale = args.viewportScale
         _DemoServer.viewportMaxWidth = args.viewportMaxWidth
         _DemoServer.viewportMaxHeight = args.viewportMaxHeight
@@ -66,8 +66,8 @@ class _DemoServer(pv_wslink.PVServerProtocol):
         # Disable interactor-based render calls
         simple.GetRenderView().EnableRenderOnInteraction = 0
 
-        # The NetCDF file with the data
-        self.enlil = EnlilDataset(self.data_file)
+        # The directory containing the NetCDF file with the data
+        self.enlil = EnlilDataset(self.data_dir)
         # Register the Paraview protocols for dispatching methods
         self.registerVtkWebProtocol(self.enlil)
 


### PR DESCRIPTION
This adds the ability to change runs on the backend. It also adds the ability for the frontend to query what runs are available.

Note that for this version I'm using the directory name as the run identifier, we can get fancier later with more metadata and such, but for now this seems like the low-hanging fruit to also keep the current version working as-is.

So, our data drive should look something like
```bash
/data/run1/pv-data-3d.nc
/data/run2/pv-data-3d.nc
```
Our current version has the data directory with only one run in it, and that will still work and the frontend should see a `/data` returned as the only run available.