### PR TITLE
Swt 262 add tubes for the streamtracer

### DIFF
--- a/pvw/server/enlil.py
+++ b/pvw/server/enlil.py
@@ -144,13 +144,15 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
 
         # create a new 'Glyph' in longitude (Arrow/vectors)
         self.lon_arrows = pvs.Glyph(
-            registrationName='Lon-B-Arrows', Input=self.lon_slice,
+            registrationName='Lon-B-Arrows', Input=self.lon_streamlines,
             GlyphType='Arrow')
-        self.lon_arrows.OrientationArray = ['CELLS', 'Bvec']
+        self.lon_arrows.OrientationArray = ['POINTS', 'Bvec']
         self.lon_arrows.ScaleArray = ['POINTS', 'No scale array']
         self.lon_arrows.ScaleFactor = 0.1
         self.lon_arrows.GlyphTransform = 'Transform2'
-        self.lon_arrows.MaximumNumberOfSamplePoints = 500
+        self.lon_arrows.GlyphMode = 'Every Nth Point'
+        self.lon_arrows.MaximumNumberOfSamplePoints = 50
+        self.lon_arrows.Stride = 50
 
         # Create a Latitude slice
         self.lat_slice = pvs.Slice(
@@ -323,26 +325,8 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
         # trace defaults for the display properties.
         disp.Representation = 'Surface'
         disp.ColorArrayName = [None, '']
-        disp.OSPRayScaleArray = 'AngularVelocity'
-        disp.OSPRayScaleFunction = 'PiecewiseFunction'
-        disp.SelectOrientationVectors = 'Normals'
-        disp.ScaleFactor = 0.3336487650871277
-        disp.SelectScaleArray = 'AngularVelocity'
-        disp.GlyphType = 'Arrow'
-        disp.GlyphTableIndexArray = 'AngularVelocity'
-        disp.GaussianRadius = 0.016682438254356384
-        disp.SetScaleArray = ['POINTS', 'AngularVelocity']
-        disp.ScaleTransferFunction = 'PiecewiseFunction'
-        disp.OpacityArray = ['POINTS', 'AngularVelocity']
-        disp.OpacityTransferFunction = 'PiecewiseFunction'
-        disp.DataAxesGrid = 'GridAxesRepresentation'
-        disp.PolarAxes = 'PolarAxesRepresentation'
-        # init the 'PiecewiseFunction' selected for 'ScaleTransferFunction'
-        disp.ScaleTransferFunction.Points = [
-            0.0, 0.0, 0.5, 0.0, 0, 1.0, 0.5, 0.0]
-        # init the 'PiecewiseFunction' selected for 'OpacityTransferFunction'
-        disp.OpacityTransferFunction.Points = [
-            0.0, 0.0, 0.5, 0.0, 0, 1.0, 0.5, 0.0]
+        # Set the linewidth of the streamlines
+        disp.LineWidth = 2
 
         # Longitude B-field vectors
         disp = pvs.Show(self.lon_arrows, self.view,

--- a/pvw/server/enlil.py
+++ b/pvw/server/enlil.py
@@ -170,10 +170,10 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
             GlyphType='Cone')
         self.lon_arrows.OrientationArray = ['POINTS', 'Bvec']
         self.lon_arrows.ScaleArray = ['POINTS', 'No scale array']
-        self.lon_arrows.ScaleFactor = 0.08
-        self.lon_arrows.GlyphType.Resolution = 30
-        self.lon_arrows.GlyphType.Radius = 0.2
-        self.lon_arrows.GlyphType.Height = 0.75
+        self.lon_arrows.ScaleFactor = 1
+        self.lon_arrows.GlyphType.Resolution = 60
+        self.lon_arrows.GlyphType.Radius = 0.02
+        self.lon_arrows.GlyphType.Height = 0.08
         self.lon_arrows.GlyphTransform = 'Transform2'
         self.lon_arrows.GlyphMode = 'Every Nth Point'
         self.lon_arrows.GlyphMode = ('Uniform Spatial Distribution '
@@ -352,8 +352,8 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
         # separate=True makes sure it doesn't overwrite the Br of the
         # frontend choices
         bpLUT = pvs.GetColorTransferFunction('Br', disp, separate=True)
-        bpLUT.RGBPoints = [-1e5, 0, 0, 0,
-                           1e5, 1, 1, 1]
+        bpLUT.RGBPoints = [-1e5, 0.5, 0.5, 0.5,
+                           1e5, 0.9, 0.9, 0.9]
         bpLUT.ScalarRangeInitialized = 1.0
         bpLUT.NumberOfTableValues = 2
         self.displays[self.lon_streamlines] = disp


### PR DESCRIPTION
This updates the streamlines and calculations surrounding them. It
uses CellDatatoPointData on the slice, which helps with the representations
of all the variables downstream (Tube/Arrows). Everything is now constrained
to the longitude plane orientation.

Additionally, this adds color based on the polarity of the variable. That needs
a separate colormap because we already have the Br variable as a frontend
selectable quantity.

Finally, the arrows are combined with the streamlines, so turning on/off the
streamlines will control both the lines and arrows.

<img width="705" alt="image" src="https://user-images.githubusercontent.com/12417828/164801709-c265fb6d-4b92-4a4c-adab-3fee6475e42c.png">
