### PR TITLE
ENH: Make colorbar horizontal

### DIFF
--- a/pvw/server/enlil.py
+++ b/pvw/server/enlil.py
@@ -357,17 +357,6 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
         disp.ColorArrayName = [None, '']
         disp.DiffuseColor = [1, 1, 1]
 
-        # setup the color legend parameters for each legend in this view
-        # get color legend/bar for bzLUT in view self.view
-        bzLUTColorBar = pvs.GetScalarBar(bzLUT, self.view)
-        bzLUTColorBar.Title = 'Bz'
-        bzLUTColorBar.ComponentTitle = ''
-        # set color bar visibility
-        bzLUTColorBar.Visibility = 1
-
-        # show color legend
-        self.displays[self.lon_slice].SetScalarBarVisibility(self.view, True)
-
         # Set colormaps
         for name in VARIABLE_MAP:
             self.set_colormap(name)
@@ -541,6 +530,14 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
                 # We don't want to update the longitude arrow colors
                 continue
             pvs.ColorBy(disp, variable)
+
+            # Also update the colorbar orientation information
+            if disp.LookupTable is None:
+                continue
+            cbar = pvs.GetScalarBar(disp.LookupTable, self.view)
+            cbar.AutoOrient = 0
+            cbar.Orientation = 'Horizontal'
+            cbar.TextPosition = 'Ticks left/bottom, annotations right/top'
 
         self.update_opacity(variable)
         self.update_lut(variable)

--- a/pvw/server/enlil.py
+++ b/pvw/server/enlil.py
@@ -53,6 +53,15 @@ VARIABLE_MAP = {'velocity': 'Vr',
                 'by': 'By',
                 'bz': 'Bz'}
 
+VARIABLE_LABEL = {'velocity': 'Velocity (km/s)',
+                  'density': 'Density (r$^2$N/cm$^3$)',
+                  'pressure': 'Ram pressure (r$^2$N/cm$^3$ * km$^2$/s$^2$)',
+                  'temperature': 'Temperature (K)',
+                  'b': 'Br (nT)',
+                  'bx': 'Bx (nT)',
+                  'by': 'By (nT)',
+                  'bz': 'Bz (nT)'}
+
 # List of satellite colors
 SATELLITE_COLORS = {"earth": [0.0, 0.3333333333333333, 0.0],
                     "stereoa": [177/255, 138/255, 142/255],
@@ -523,6 +532,7 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
         """
         # Use a dictionary to map the variable received to the internal name
         variable = VARIABLE_MAP[name]
+        label = VARIABLE_LABEL[name]
 
         # Update all displays to be colored by this variable
         for obj, disp in self.displays.items():
@@ -538,6 +548,8 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
             cbar.AutoOrient = 0
             cbar.Orientation = 'Horizontal'
             cbar.TextPosition = 'Ticks left/bottom, annotations right/top'
+            cbar.Title = label
+            cbar.ComponentTitle = ""
 
         self.update_opacity(variable)
         self.update_lut(variable)


### PR DESCRIPTION
This sets the colorbar to be horizontal. This has to be done
in the change variable routine otherwise it would only occur
for the first variable chosen and not capture the updates.
We also need to iterate over all "displays" here because I wasn't
able to get it working for a single display selection. (I tried
the last display, and the lon_slice directly and neither worked)

<img width="709" alt="image" src="https://user-images.githubusercontent.com/12417828/164814646-95c1d911-3497-45f4-9209-ca9b0f92d15c.png">
