### PR TITLE
ENH: Add ability to get data range from the frontend

### DIFF
--- a/pvw/server/enlil.py
+++ b/pvw/server/enlil.py
@@ -489,6 +489,17 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
                 if os.path.exists(os.path.join(x, "pv-data-3d.nc"))]
         return dirs
 
+    @exportRpc("pv.enlil.get_variable_range")
+    def get_variable_range(self, name):
+        """
+        Get the range of values for a variable at the current timestep.
+
+        name : str
+            Name of variable to colormap all of the surfaces by
+        """
+        variable = VARIABLE_MAP[name]
+        return self.data.CellData.GetArray(variable).GetRange()
+
     @exportRpc("pv.enlil.directory")
     def update_dataset(self, dirname):
         """


### PR DESCRIPTION
This adds a small wrapper to get the data variable range (min, max) of the entire domain for the current timestep.

@jennyknuth, you'll call: `pv.enlil.get_variable_range` with the variable name you want to get the range for and it will return a two-item tuple `(min, max)` to you. Note that it is only per-timestep, so not for the entire animation.