### PR TITLE
Add Isocontours to the CME

### DIFF
--- a/pvw/server/enlil.py
+++ b/pvw/server/enlil.py
@@ -107,7 +107,6 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
         # work better and faster
         self.cme = pvs.ResampleToImage(registrationName='resampled_cme',
                                        Input=self.threshold_cme)
-        # self.cme.SamplingBounds = [-1.5, 0, -1.5, 1.5, -1.5, 1.5]
 
         # Create a threshold that can be modified by the user
         self.threshold_data = pvs.Threshold(registrationName='Threshold',
@@ -175,7 +174,7 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
         self.view.CameraFocalPoint = [0, 0, 0]
         self.view.CameraViewUp = [0, 0, 1]
         self.view.CameraFocalDisk = 1.0
-        self.view.CameraParallelScale = 2.1250001580766877
+        self.view.CameraParallelScale = 2
         self.view.BackEnd = 'OSPRay raycaster'
         self.view.OSPRayMaterialLibrary = pvs.GetMaterialLibrary()
 

--- a/pvw/server/enlil.py
+++ b/pvw/server/enlil.py
@@ -365,6 +365,7 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
         # NOTE: In the processing steps, we multiply
         #       Br * sign(BP), meaning the Br here contains the
         #       polarity implicitly.
+        point_data.ProcessAllArrays = 0
         point_data.CellDataArraytoprocess = ['Br', 'Bvec']
 
         stream_input = pvs.StreamTracerWithCustomSource(

--- a/pvw/server/enlil.py
+++ b/pvw/server/enlil.py
@@ -182,10 +182,7 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
         disp = pvs.Show(self.time_string, self.view,
                         'TextSourceRepresentation')
 
-        # TODO: Show the base dataset?
-        # pvs.Show(self.data, self.view, 'StructuredGridRepresentation')
-
-        # get color transfer function/color map for 'Bz'
+        # get color transfer function/color map for Bz initially
         bzLUT = pvs.GetColorTransferFunction('Bz')
         bzLUT.RGBPoints = [-10, 0.231373, 0.298039, 0.752941,
                            0, 0.865003, 0.865003, 0.865003,
@@ -201,94 +198,41 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
         disp = pvs.Show(self.cme, self.view,
                         'UniformGridRepresentation')
         self.displays[self.cme] = disp
-        # trace defaults for the display properties.
         disp.Representation = 'Volume'
         disp.ColorArrayName = ['POINTS', 'Bz']
         disp.LookupTable = bzLUT
-        disp.OSPRayScaleFunction = 'PiecewiseFunction'
-        disp.SelectOrientationVectors = 'None'
-        disp.ScaleFactor = 0.09197479853610144
-        disp.SelectScaleArray = 'None'
-        disp.GlyphType = 'Arrow'
-        disp.GlyphTableIndexArray = 'None'
-        disp.GaussianRadius = 0.004598739926805072
-        disp.SetScaleArray = [None, '']
-        disp.ScaleTransferFunction = 'PiecewiseFunction'
         disp.OpacityArray = [None, '']
         disp.OpacityTransferFunction = 'PiecewiseFunction'
-        disp.DataAxesGrid = 'GridAxesRepresentation'
-        disp.PolarAxes = 'PolarAxesRepresentation'
         disp.ScalarOpacityFunction = bzPWF
-        disp.ScalarOpacityUnitDistance = 0.02090409368521722
+        disp.ScalarOpacityUnitDistance = 0.02
         disp.OpacityArrayName = [None, '']
 
         disp = pvs.Show(self.threshold, self.view,
                         'UniformGridRepresentation')
         self.displays[self.threshold] = disp
-        # trace defaults for the display properties.
         disp.Representation = 'Volume'
         disp.ColorArrayName = ['POINTS', 'Bz']
         disp.LookupTable = bzLUT
-        disp.OSPRayScaleFunction = 'PiecewiseFunction'
-        disp.SelectOrientationVectors = 'None'
-        disp.ScaleFactor = 0.09197479853610144
-        disp.SelectScaleArray = 'None'
-        disp.GlyphType = 'Arrow'
-        disp.GlyphTableIndexArray = 'None'
-        disp.GaussianRadius = 0.004598739926805072
-        disp.SetScaleArray = [None, '']
-        disp.ScaleTransferFunction = 'PiecewiseFunction'
         disp.OpacityArray = [None, '']
         disp.OpacityTransferFunction = 'PiecewiseFunction'
-        disp.DataAxesGrid = 'GridAxesRepresentation'
-        disp.PolarAxes = 'PolarAxesRepresentation'
         disp.ScalarOpacityFunction = bzPWF
-        disp.ScalarOpacityUnitDistance = 0.02090409368521722
+        disp.ScalarOpacityUnitDistance = 0.02
         disp.OpacityArrayName = [None, '']
 
         # Latitude
         disp = pvs.Show(self.lat_slice, self.view,
                         'GeometryRepresentation')
         self.displays[self.lat_slice] = disp
-
-        # trace defaults for the display properties.
         disp.Representation = 'Surface'
         disp.ColorArrayName = ['CELLS', 'Bz']
         disp.LookupTable = bzLUT
-        disp.OSPRayScaleFunction = 'PiecewiseFunction'
-        disp.SelectOrientationVectors = 'Bvec'
-        disp.ScaleFactor = 0.2944486496874232
-        disp.SelectScaleArray = 'None'
-        disp.GlyphType = 'Arrow'
-        disp.GlyphTableIndexArray = 'None'
-        disp.GaussianRadius = 0.01472243248437116
-        disp.SetScaleArray = [None, '']
-        disp.ScaleTransferFunction = 'PiecewiseFunction'
-        disp.OpacityArray = [None, '']
-        disp.OpacityTransferFunction = 'PiecewiseFunction'
-        disp.DataAxesGrid = 'GridAxesRepresentation'
-        disp.PolarAxes = 'PolarAxesRepresentation'
 
         # Longitude
         disp = pvs.Show(self.lon_slice, self.view, 'GeometryRepresentation')
         self.displays[self.lon_slice] = disp
-        # trace defaults for the display properties.
         disp.Representation = 'Surface'
         disp.ColorArrayName = ['CELLS', 'Bz']
         disp.LookupTable = bzLUT
-        disp.OSPRayScaleFunction = 'PiecewiseFunction'
-        disp.SelectOrientationVectors = 'Bvec'
-        disp.ScaleFactor = 0.340000014164759
-        disp.SelectScaleArray = 'None'
-        disp.GlyphType = 'Arrow'
-        disp.GlyphTableIndexArray = 'None'
-        disp.GaussianRadius = 0.017000000708237952
-        disp.SetScaleArray = [None, '']
-        disp.ScaleTransferFunction = 'PiecewiseFunction'
-        disp.OpacityArray = [None, '']
-        disp.OpacityTransferFunction = 'PiecewiseFunction'
-        disp.DataAxesGrid = 'GridAxesRepresentation'
-        disp.PolarAxes = 'PolarAxesRepresentation'
 
         # Streamlines
         disp = pvs.Show(self.lon_streamlines, self.view,

--- a/pvw/server/enlil.py
+++ b/pvw/server/enlil.py
@@ -300,20 +300,6 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
             disp.AmbientColor = SATELLITE_COLORS[x]
             disp.ColorArrayName = [None, '']
             disp.DiffuseColor = SATELLITE_COLORS[x]
-            disp.OSPRayScaleArray = 'Normals'
-            disp.OSPRayScaleFunction = 'PiecewiseFunction'
-            disp.SelectOrientationVectors = 'None'
-            disp.ScaleFactor = 0.005000000074505806
-            disp.SelectScaleArray = 'None'
-            disp.GlyphType = 'Arrow'
-            disp.GlyphTableIndexArray = 'None'
-            disp.GaussianRadius = 0.0002500000037252903
-            disp.SetScaleArray = ['POINTS', 'Normals']
-            disp.ScaleTransferFunction = 'PiecewiseFunction'
-            disp.OpacityArray = ['POINTS', 'Normals']
-            disp.OpacityTransferFunction = 'PiecewiseFunction'
-            disp.DataAxesGrid = 'GridAxesRepresentation'
-            disp.PolarAxes = 'PolarAxesRepresentation'
 
         # Sun representation
         self.sun = pvs.Sphere()
@@ -328,20 +314,6 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
         disp.AmbientColor = [0.8313725490196079, 0.8313725490196079, 0.0]
         disp.ColorArrayName = [None, '']
         disp.DiffuseColor = [0.8313725490196079, 0.8313725490196079, 0.0]
-        disp.OSPRayScaleArray = 'Normals'
-        disp.OSPRayScaleFunction = 'PiecewiseFunction'
-        disp.SelectOrientationVectors = 'None'
-        disp.ScaleFactor = 0.020000000298023225
-        disp.SelectScaleArray = 'None'
-        disp.GlyphType = 'Arrow'
-        disp.GlyphTableIndexArray = 'None'
-        disp.GaussianRadius = 0.0010000000149011613
-        disp.SetScaleArray = ['POINTS', 'Normals']
-        disp.ScaleTransferFunction = 'PiecewiseFunction'
-        disp.OpacityArray = ['POINTS', 'Normals']
-        disp.OpacityTransferFunction = 'PiecewiseFunction'
-        disp.DataAxesGrid = 'GridAxesRepresentation'
-        disp.PolarAxes = 'PolarAxesRepresentation'
 
         # Apply an image to the Earth sphere
         self.apply_earth_texture()


### PR DESCRIPTION
This adds the ability to add/change contours within the CME volume. Similar to threshold you can control it with the variable and levels of contouring you want. So, the frontend should call `pv.enlil.set_contours` with `("density", [5, 7.5, 10, 15])` to get density contours at 5, 7.5, 10, 15. You can add/remove by just calling that function with an updated list of quantities.

This is on top of #24, so the final commit is the one with the isocontouring work.