### PR TITLE
FIX: Hide the streamlines colorbar

### DIFF
--- a/pvw/server/enlil.py
+++ b/pvw/server/enlil.py
@@ -589,6 +589,9 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
         # hides old scalarbars that aren't in the view and
         # shows the new variable we are using now
         pvs.UpdateScalarBars(self.view)
+        # But we want to hide the streamlines colorbar
+        disp = self.displays[self.lon_streamlines]
+        disp.SetScalarBarVisibility(self.view, False)
 
         # restore active source
         pvs.SetActiveSource(None)


### PR DESCRIPTION
Noticed this while testing other things...

If the color variable was changed, the streamline colorbar would
also show up in the view. This hides that again anytime a variable
is changed.