### PR TITLE
FIX: Remove the /frontend endpoint and replace with a redirect page

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ copied into the container.
 3. Run the image setting the proper environment variables and mounting the proper directories.
 
     ```bash
-    docker run -p 0.0.0.0:9000:80 -e SERVER_NAME=127.0.0.1:9000 -e PROTOCOL=ws -v ${PWD}/pvw:/pvw -v ${PWD}/data:/data -v /path/to/frontend/dist/swt:/frontend -it pvw-enlil-osmesa
+    docker run -p 0.0.0.0:9000:80 -e SERVER_NAME=127.0.0.1:9000 -e PROTOCOL=ws -v ${PWD}/pvw:/pvw -v ${PWD}/data:/data -it pvw-enlil-osmesa
     ```
 
     The container requires several input volumes that contain the data directory (that contains

--- a/pvw/endpoints.txt
+++ b/pvw/endpoints.txt
@@ -1,1 +1,0 @@
-DOCUMENT-ROOT-DIRECTORY /frontend

--- a/pvw/www/index.html
+++ b/pvw/www/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+<h1>Please visit https://enlil.swx-trec.com to access the visualizer.</h1>
+
+</body>
+</html>


### PR DESCRIPTION
This removes the endpoint redirect to /frontend, which eliminates
the initial warning during the container startup.

I also put a blank page with a redirect in case someone reaches that.