### PR TITLE
Add Satellite names and change to box instead of sphere

### DIFF
--- a/pvw/server/enlil.py
+++ b/pvw/server/enlil.py
@@ -303,16 +303,22 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
             if x not in self.evolutions:
                 continue
 
-            # All satellites are represented as a sphere
-            sat = pvs.Sphere()
+            # All satellites are represented as a box, except the Earth
+            if x == "earth":
+                sat = pvs.Sphere()
+                sat.Radius = 0.025
+            else:
+                sat = pvs.Box()
+                radius = 0.02
+                sat.XLength = radius
+                sat.YLength = radius
+                sat.ZLength = radius
             setattr(self, x, sat)
             # TODO: What coordinate system do we want x/y/z to be in?
             #       The base model is rotated 180 degrees, should we
             #       automatically rotate it for the users?
             evo = self.evolutions[x]
-
             sat.Center = evo.get_position(curr_time)
-            sat.Radius = 0.025
 
             disp = pvs.Show(sat, self.view,
                             'GeometryRepresentation')

--- a/pvw/server/enlil.py
+++ b/pvw/server/enlil.py
@@ -67,6 +67,11 @@ SATELLITE_COLORS = {"earth": [0.0, 0.3333333333333333, 0.0],
                     "stereoa": [177/255, 138/255, 142/255],
                     "stereob": [94/255, 96/255, 185/255]}
 
+# Keep track of the name mapping that we want to show to users
+SATELLITE_NAMES = {"earth": "Earth",
+                   "stereoa": "STEREO-A",
+                   "stereob": "STEREO-B"}
+
 
 class EnlilDataset(pv_protocols.ParaViewWebProtocol):
     def __init__(self, dirname):
@@ -327,6 +332,19 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
             disp.AmbientColor = SATELLITE_COLORS[x]
             disp.ColorArrayName = [None, '']
             disp.DiffuseColor = SATELLITE_COLORS[x]
+
+            if x != "earth":
+                # Label all non-earth satellites
+                sat_label = pvs.Text()
+                sat_label.Text = SATELLITE_NAMES[x]
+                disp = pvs.Show(sat_label, self.view,
+                                'TextSourceRepresentation')
+                disp.TextPropMode = 'Billboard 3D Text'
+                disp.FontSize = 14
+                disp.WindowLocation = 'AnyLocation'
+                # Offset the center by the width to give some separation
+                disp.BillboardPosition = [x + sat.XLength for x in sat.Center]
+                disp.Color = [0, 0, 0]  # Black text
 
         # Sun representation
         self.sun = pvs.Sphere()


### PR DESCRIPTION
* Change from sphere to box for visualization of satellites
* Add text labels to the satellites
* Add ability to toggle the labels on/off

You can toggle the satellites and text on/off with `pv.enlil.toggle_satellites` and sending the string "on" or "off"