### PR TITLE
Performance work

### DIFF
--- a/pvw/launcher/config.json
+++ b/pvw/launcher/config.json
@@ -32,7 +32,9 @@
   },
   "apps": {
     "visualizer": {
-      "cmd": ["${python_exec}",
+      "cmd": ["env", "PARAVIEW_LOG_EXECUTION_VERBOSITY=INFO",
+        "env", "PARAVIEW_LOG_RENDERING_VERBOSITY=INFO",
+        "${python_exec}",
         EXTRA_PVPYTHON_ARGS
         "/pvw/server/pv_server_statefile.py",
         "--port", "${port}",

--- a/pvw/server/enlil.py
+++ b/pvw/server/enlil.py
@@ -177,8 +177,8 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
         # disable automatic camera reset on 'Show'
         pvs._DisableFirstRenderCameraReset()
 
-        # Create a new 'Render View'
-        self.view = pvs.CreateView('RenderView')
+        # Get the initial 'Render View'
+        self.view = pvs.GetActiveView()
         self.view.ViewSize = [600, 600]
         self.view.AxesGrid = 'GridAxes3DActor'
         self.view.CenterOfRotation = [0, 0, 0]


### PR DESCRIPTION
This should speed things up a bit by lazy-evaluating the CME/Threshold if they aren't "checked" by the user. Everything should still work the same as expected.

Additionally, this adds much more verbose logging to the application, so we can start doing some more detailed performance testing.