### PR TITLE
FIX: Disable colorbar range labels

### DIFF
--- a/pvw/server/enlil.py
+++ b/pvw/server/enlil.py
@@ -587,6 +587,8 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
             cbar.TextPosition = 'Ticks left/bottom, annotations right/top'
             cbar.Title = label
             cbar.ComponentTitle = ""
+            # Disables the endpoints which can be formatted differently
+            cbar.AddRangeLabels = 0
 
         self.update_opacity(variable)
         self.update_lut(variable)


### PR DESCRIPTION
This removes the endpoint range labels because they can be formatted differently than the main ticks.

Would it be better to manually control the formatting for everything? The problem is we have some values that are best shown in scientific notation and others as just integers... So I think we'd have to manually keep track/choose which formatting we want. I'm open to suggestions here if you don't like this new look.