### PR TITLE
FIX: Remove extra subset from evolution index

### DIFF
--- a/pvw/server/evolution.py
+++ b/pvw/server/evolution.py
@@ -76,7 +76,7 @@ class Evolution:
             # the units to be in milliseconds
             curr_row = [int(self.get_times()[i]) * 1000]
             for var in ["Density", "Vr", "Pressure", "T", "Bx", "By", "Bz"]:
-                curr_row.append(self.get_data(var)[i][0])
+                curr_row.append(self.get_data(var)[i])
             timestep_data.append(curr_row)
 
         json_out = {


### PR DESCRIPTION
This fixes a bug with going one level too deep in the evolution files.
The files must have been updated in the processing step at some point
and wasn't propagated through to this.