### PR TITLE
Add EUHFORIA data model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Enlil 3D Server
+# H3LIO Viz
 
 This repository hosts the code to run a Paraview server for
-the 3D Enlil output.
+the 3D heliospheric output, from codes such as Enlil and EUHFORIA.
 
 ## Local Development and Testing
 
@@ -102,7 +102,7 @@ pip install wslink
 Now, you can run the server with
 
 ```bash
-pvpython pvw/server/pv_server_statefile.py --port 1234 --dir /path/to/<pv-data-3d.nc>
+pvpython pvw/server/app_server.py --port 1234 --dir /path/to/<pv-data-3d.nc>
 ```
 
 where the port is `1234` for local development, and the path to the input file is

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# H3LIO Viz
+# H3lioViz
 
 This repository hosts the code to run a Paraview server for
-the 3D heliospheric output, from codes such as Enlil and EUHFORIA.
+the 3D heliospheric output, from codes such as Enlil and Euhforia.
 
 ## Local Development and Testing
 

--- a/pvw/launcher/config.json
+++ b/pvw/launcher/config.json
@@ -36,7 +36,7 @@
         "env", "PARAVIEW_LOG_RENDERING_VERBOSITY=INFO",
         "${python_exec}",
         EXTRA_PVPYTHON_ARGS
-        "/pvw/server/pv_server_statefile.py",
+        "/pvw/server/app_server.py",
         "--port", "${port}",
         "--authKey", "${secret}",
         "--dir", "/data",

--- a/pvw/server/app.py
+++ b/pvw/server/app.py
@@ -66,14 +66,14 @@ VARIABLE_LABEL = {
 }
 
 
-class EnlilDataset(pv_protocols.ParaViewWebProtocol):
+class App(pv_protocols.ParaViewWebProtocol):
     def __init__(self, dirname):
         """
-        Enlil 4D dataset representation in Paraview.
+        Heliosphere 4D dataset representation in Paraview.
 
-        This class will read in the given NetCDF file that contains
-        the Enlil output. It is designed to enable an easy storage
-        and access layer to the data.
+        This class is the base app designed to enable an easy storage
+        and access layer to the data, which is stored in the models
+        module.
         """
         # Initialize the PV web protocols
         super().__init__()

--- a/pvw/server/app.py
+++ b/pvw/server/app.py
@@ -277,7 +277,7 @@ class App(pv_protocols.ParaViewWebProtocol):
             self.satellites[sat].add_fieldline(self.bvec)
         self.earth.add_fieldline(self.bvec)
 
-    @exportRpc("pv.enlil.get_available_runs")
+    @exportRpc("pv.h3lioviz.get_available_runs")
     def get_available_runs(self):
         """
         Get a list of available runs to choose from.
@@ -299,7 +299,7 @@ class App(pv_protocols.ParaViewWebProtocol):
         dirs = [x for x in base_dir.iterdir() if (x / "pv-data-3d.nc").exists()]
         return dirs
 
-    @exportRpc("pv.enlil.get_variable_range")
+    @exportRpc("pv.h3lioviz.get_variable_range")
     def get_variable_range(self, name):
         """
         Get the range of values for a variable at the current timestep.
@@ -310,7 +310,7 @@ class App(pv_protocols.ParaViewWebProtocol):
         variable = getattr(self.model, name)
         return self.celldata.CellData.GetArray(variable).GetRange()
 
-    @exportRpc("pv.enlil.directory")
+    @exportRpc("pv.h3lioviz.directory")
     def update_dataset(self, dirname):
         """
         Change the dataset directory to the one specified by dirname
@@ -333,7 +333,7 @@ class App(pv_protocols.ParaViewWebProtocol):
         self.data.UpdatePipeline()
         pvs.Render(self.view)
 
-    @exportRpc("pv.enlil.visibility")
+    @exportRpc("pv.h3lioviz.visibility")
     def change_visibility(self, obj, visibility):
         """
         Change the visibility of an object.
@@ -381,7 +381,7 @@ class App(pv_protocols.ParaViewWebProtocol):
         else:
             return ["Visibility can only be 'on' or 'off'"]
 
-    @exportRpc("pv.enlil.colorby")
+    @exportRpc("pv.h3lioviz.colorby")
     def change_color_variable(self, name):
         """
         Change the visibility of an object.
@@ -487,7 +487,7 @@ class App(pv_protocols.ParaViewWebProtocol):
         else:
             raise ValueError("Opacity needs 2 or 3 points to map")
 
-    @exportRpc("pv.enlil.set_colormap")
+    @exportRpc("pv.h3lioviz.set_colormap")
     def set_colormap(self, name, cmap_name=None):
         """
         Set the colormap for the variable.
@@ -504,7 +504,7 @@ class App(pv_protocols.ParaViewWebProtocol):
         lut.ApplyPreset(cmap_name or DEFAULT_CMAP[name])
         lut.EnableOpacityMapping = 1
 
-    @exportRpc("pv.enlil.set_range")
+    @exportRpc("pv.h3lioviz.set_range")
     def set_range(self, name, range):
         """
         Set the range of values used for colormapping.
@@ -517,7 +517,7 @@ class App(pv_protocols.ParaViewWebProtocol):
         LUT_RANGE[name] = range
         self.update_lut(name)
 
-    @exportRpc("pv.enlil.set_opacity")
+    @exportRpc("pv.h3lioviz.set_opacity")
     def set_opacity(self, name, range):
         """
         Set the range of values used for opacity-mapping.
@@ -535,7 +535,7 @@ class App(pv_protocols.ParaViewWebProtocol):
         OPACITY_VALUES[name] = range
         self.update_opacity(name)
 
-    @exportRpc("pv.enlil.set_threshold")
+    @exportRpc("pv.h3lioviz.set_threshold")
     def set_threshold(self, name, range):
         """
         Set the variable and range of values to be used for the threshold.
@@ -550,7 +550,7 @@ class App(pv_protocols.ParaViewWebProtocol):
         self.threshold.ContourBy = ["POINTS", variable]
         self.threshold.Isosurfaces = range
 
-    @exportRpc("pv.enlil.set_contours")
+    @exportRpc("pv.h3lioviz.set_contours")
     def set_contours(self, name, values):
         """
         Set the variable and a list of values to be used for the contours.
@@ -565,7 +565,7 @@ class App(pv_protocols.ParaViewWebProtocol):
         self.cme_contours.ContourBy = ["POINTS", variable]
         self.cme_contours.Isosurfaces = values
 
-    @exportRpc("pv.enlil.snap_solar_plane")
+    @exportRpc("pv.h3lioviz.snap_solar_plane")
     def snap_solar_plane(self, clip):
         """Snap the solar plane to either the solar equator or Sun-Earth plane.
 
@@ -595,7 +595,7 @@ class App(pv_protocols.ParaViewWebProtocol):
         # Also update the stream source so they stay in-sync
         self.lon_slice.stream_source.Normal = loc
 
-    @exportRpc("pv.enlil.rotate_plane")
+    @exportRpc("pv.h3lioviz.rotate_plane")
     def rotate_plane(self, plane, angle):
         """
         Rotate the desired plane to the given angle.
@@ -622,7 +622,7 @@ class App(pv_protocols.ParaViewWebProtocol):
         else:
             raise ValueError("You can only update the 'lon' or 'lat' plane.")
 
-    @exportRpc("pv.enlil.snap_to_view")
+    @exportRpc("pv.h3lioviz.snap_to_view")
     def snap_to_view(self, plane):
         """Snap to the given planar view
 
@@ -651,7 +651,7 @@ class App(pv_protocols.ParaViewWebProtocol):
         # Force the focal point to be the sun
         self.view.CameraFocalPoint = [0, 0, 0]
 
-    @exportRpc("pv.enlil.toggle_satellites")
+    @exportRpc("pv.h3lioviz.toggle_satellites")
     def toggle_satellites(self, visibility):
         """
         Toggles the visibility of the satellites on/off from the view
@@ -669,7 +669,7 @@ class App(pv_protocols.ParaViewWebProtocol):
             # Call the hide() or show() method
             getattr(self.satellites[sat], hide_show)()
 
-    @exportRpc("pv.enlil.get_satellite_times")
+    @exportRpc("pv.h3lioviz.get_satellite_times")
     def get_satellite_time(self, sat):
         """
         Returns a time-series of data for the given satellite and variable.
@@ -687,7 +687,7 @@ class App(pv_protocols.ParaViewWebProtocol):
             return self.earth.get_times()
         return self.satellites[sat].get_times()
 
-    @exportRpc("pv.enlil.get_satellite_data")
+    @exportRpc("pv.h3lioviz.get_satellite_data")
     def get_satellite_data(self, sat):
         """
         Returns a time-series of data for the given satellite and variable.

--- a/pvw/server/app_server.py
+++ b/pvw/server/app_server.py
@@ -7,16 +7,15 @@ from paraview.web import protocols as pv_protocols
 from paraview import simple
 from wslink import server
 
-from enlil import EnlilDataset
+from app import App
 
 # =============================================================================
 # Create custom PVServerProtocol class to handle clients requests
 # =============================================================================
 
 
-class _DemoServer(pv_wslink.PVServerProtocol):
+class _AppServer(pv_wslink.PVServerProtocol):
     authKey = "wslink-secret"
-    data_file = "/data/pv-data-3d.nc"
     viewportScale = 1.0
     viewportMaxWidth = 2560
     viewportMaxHeight = 1440
@@ -27,7 +26,7 @@ class _DemoServer(pv_wslink.PVServerProtocol):
         parser.add_argument(
             "--dir",
             default="/data",
-            help=("Path to the NetCDF file to load"),
+            help=("Path to the data directory to load"),
             dest="data_dir",
         )
         parser.add_argument(
@@ -62,12 +61,12 @@ class _DemoServer(pv_wslink.PVServerProtocol):
     @staticmethod
     def configure(args):
         # Update this server based on the passed in arguments
-        _DemoServer.authKey = args.authKey
-        _DemoServer.data_dir = args.data_dir
-        _DemoServer.viewportScale = args.viewportScale
-        _DemoServer.viewportMaxWidth = args.viewportMaxWidth
-        _DemoServer.viewportMaxHeight = args.viewportMaxHeight
-        _DemoServer.settingsLODThreshold = args.settingsLODThreshold
+        _AppServer.authKey = args.authKey
+        _AppServer.data_dir = args.data_dir
+        _AppServer.viewportScale = args.viewportScale
+        _AppServer.viewportMaxWidth = args.viewportMaxWidth
+        _AppServer.viewportMaxHeight = args.viewportMaxHeight
+        _AppServer.settingsLODThreshold = args.settingsLODThreshold
 
     def initialize(self):
         # Bring used components
@@ -77,7 +76,7 @@ class _DemoServer(pv_wslink.PVServerProtocol):
         self.registerVtkWebProtocol(
             pv_protocols.ParaViewWebPublishImageDelivery(decode=False)
         )
-        self.updateSecret(_DemoServer.authKey)
+        self.updateSecret(_AppServer.authKey)
 
         # tell the C++ web app to use no encoding.
         # ParaViewWebPublishImageDelivery must be set to decode=False to match.
@@ -87,22 +86,22 @@ class _DemoServer(pv_wslink.PVServerProtocol):
         simple.GetRenderView().EnableRenderOnInteraction = 0
 
         # The directory containing the NetCDF file with the data
-        self.enlil = EnlilDataset(self.data_dir)
+        self.app = App(self.data_dir)
         # Register the Paraview protocols for dispatching methods
-        self.registerVtkWebProtocol(self.enlil)
+        self.registerVtkWebProtocol(self.app)
 
 
 if __name__ == "__main__":
     # Create argument parser
-    parser = argparse.ArgumentParser(description="ParaViewWeb Demo")
+    parser = argparse.ArgumentParser(description="H3LIO Viewer")
 
     # Add default arguments
     server.add_arguments(parser)
-    _DemoServer.add_arguments(parser)
+    _AppServer.add_arguments(parser)
 
     # Extract arguments
     args = parser.parse_args()
-    _DemoServer.configure(args)
+    _AppServer.configure(args)
 
     # Start server
-    server.start_webserver(options=args, protocol=_DemoServer)
+    server.start_webserver(options=args, protocol=_AppServer)

--- a/pvw/server/app_server.py
+++ b/pvw/server/app_server.py
@@ -93,7 +93,7 @@ class _AppServer(pv_wslink.PVServerProtocol):
 
 if __name__ == "__main__":
     # Create argument parser
-    parser = argparse.ArgumentParser(description="H3LIO Viewer")
+    parser = argparse.ArgumentParser(description="H3lioViz")
 
     # Add default arguments
     server.add_arguments(parser)

--- a/pvw/server/enlil.py
+++ b/pvw/server/enlil.py
@@ -81,7 +81,10 @@ class EnlilDataset(pv_protocols.ParaViewWebProtocol):
         self._data_dir = pathlib.Path(dirname)
 
         self.model = models.Enlil(self._data_dir)
-        # create a new 'NetCDF Reader' from the full data path
+        # TODO: Implement a check for whether we are given Enlil or EUHFORIA data
+        # self.model = models.Euhforia(self._data_dir / "euhforia_cone_cme_example")
+
+        # Store the data locally as well
         self.celldata = self.model.data
 
         # Force all cell data to point data in the volume

--- a/pvw/server/models.py
+++ b/pvw/server/models.py
@@ -34,3 +34,55 @@ class Enlil:
         }
         for key, val in var_map.items():
             setattr(self, key, val)
+
+
+class Euhforia:
+    """
+    The 3D EUHFORIA model simulation results
+    """
+
+    def __init__(self, dirname: Path):
+        """
+        Parameters
+        ----------
+        dirname : Path
+            Path of the directory containing the EUHFORIA model output
+        """
+        self._data_dir = dirname
+        fnames = [str(fname) for fname in dirname.glob("data_*.vts")]
+        # create a new 'XML Structured Grid Reader'
+        self.data = pvs.XMLStructuredGridReader(
+            registrationName="euhforia-data", FileName=fnames
+        )
+        self.data.CellArrayStatus = ["vr", "n", "P", "Br", "Bx", "By", "Bz"]
+        self.data.TimeArray = "None"
+
+        # Now scale all the arrays we need to work with
+        self.data = pvs.CellDatatoPointData(
+            registrationName="euhforia-pointdata", Input=self.data
+        )
+        self.data.ProcessAllArrays = 1
+        self.data.PassCellData = 1
+
+        # now calculate the density with rho * r**2
+        self.data = pvs.Calculator(
+            registrationName="euhforia-calculator", Input=self.data
+        )
+        self.data.AttributeType = "Point Data"
+        self.data.ResultArrayName = "n-scaled"
+        self.data.Function = "n * (coordsX^2 + coordsY^2 + coordsZ^2)"
+
+        # Use properties for the variable mapping
+        var_map = {
+            "velocity": "vr",
+            "density": "n-scaled",
+            "pressure": "P",
+            "temperature": "T",
+            "b": "Br",
+            "bx": "Bx",
+            "by": "By",
+            "bz": "Bz",
+            "dp": "DP",
+        }
+        for key, val in var_map.items():
+            setattr(self, key, val)

--- a/pvw/server/models.py
+++ b/pvw/server/models.py
@@ -3,25 +3,62 @@ from pathlib import Path
 import paraview.simple as pvs
 
 
-class Enlil:
+class Model:
+    """Heliosphere 3D model output"""
+
+    def __init__(self, dirname: Path, variable_mapping: dict):
+        """
+        Parameters
+        ----------
+        dirname : Path
+            Path of the directory containing the model output
+        variable_mapping : dict
+            Mapping of variable names from app to model. This is
+            helpful for keeping the app with a consistent naming
+            while letting the models handle the variables themselves.
+        """
+        self._data_dir = dirname
+        required_variables = {
+            "velocity",
+            "density",
+            "pressure",
+            "temperature",
+            "b",
+            "bx",
+            "by",
+            "bz",
+            "dp",
+        }
+        for x in required_variables:
+            if x not in variable_mapping:
+                raise ValueError(
+                    f"The required variable {x} was not found in the model's variable mapping."
+                )
+        self._variable_mapping = variable_mapping
+
+    def get_variable(self, name: str) -> str:
+        """Get the variable name associated with this model
+
+        Parameters
+        ----------
+        name : str
+            The name of the variable within the App
+
+        Returns
+        -------
+        str
+            The name of the variable within the model
+        """
+        return self._variable_mapping[name]
+
+
+class Enlil(Model):
     """
     The 3D Enlil model simulation results
     """
 
     def __init__(self, dirname: Path):
-        """
-        Parameters
-        ----------
-        dirname : Path
-            Path of the directory containing the Enlil model output
-        """
-        self._data_dir = dirname
-        fname = str(self._data_dir / "pv-data-3d.nc")
-        self.data = pvs.NetCDFReader(registrationName="enlil-data", FileName=[fname])
-        self.data.Dimensions = "(longitude, latitude, radius)"
-
-        # Use properties for the variable mapping
-        var_map = {
+        variable_mapping = {
             "velocity": "Vr",
             "density": "Density",
             "pressure": "Pressure",
@@ -32,11 +69,13 @@ class Enlil:
             "bz": "Bz",
             "dp": "DP",
         }
-        for key, val in var_map.items():
-            setattr(self, key, val)
+        super().__init__(dirname=dirname, variable_mapping=variable_mapping)
+        fname = str(self._data_dir / "pv-data-3d.nc")
+        self.data = pvs.NetCDFReader(registrationName="enlil-data", FileName=[fname])
+        self.data.Dimensions = "(longitude, latitude, radius)"
 
 
-class Euhforia:
+class Euhforia(Model):
     """
     The 3D EUHFORIA model simulation results
     """
@@ -48,8 +87,20 @@ class Euhforia:
         dirname : Path
             Path of the directory containing the EUHFORIA model output
         """
-        self._data_dir = dirname
-        fnames = [str(fname) for fname in dirname.glob("data_*.vts")]
+        variable_mapping = {
+            "velocity": "vr",
+            "density": "n-scaled",
+            "pressure": "P",
+            "temperature": "T",
+            "b": "Br",
+            "bx": "Bx",
+            "by": "By",
+            "bz": "Bz",
+            "dp": "DP",
+        }
+        super().__init__(dirname=dirname, variable_mapping=variable_mapping)
+        # Glob to list all files in the data directory
+        fnames = [str(fname) for fname in self._data_dir.glob("data_*.vts")]
         # create a new 'XML Structured Grid Reader'
         self.data = pvs.XMLStructuredGridReader(
             registrationName="euhforia-data", FileName=fnames
@@ -71,18 +122,3 @@ class Euhforia:
         self.data.AttributeType = "Point Data"
         self.data.ResultArrayName = "n-scaled"
         self.data.Function = "n * (coordsX^2 + coordsY^2 + coordsZ^2)"
-
-        # Use properties for the variable mapping
-        var_map = {
-            "velocity": "vr",
-            "density": "n-scaled",
-            "pressure": "P",
-            "temperature": "T",
-            "b": "Br",
-            "bx": "Bx",
-            "by": "By",
-            "bz": "Bz",
-            "dp": "DP",
-        }
-        for key, val in var_map.items():
-            setattr(self, key, val)

--- a/pvw/server/models.py
+++ b/pvw/server/models.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import paraview.simple as pvs
+
+
+class Enlil:
+    """
+    The 3D Enlil model simulation results
+    """
+
+    def __init__(self, dirname: Path):
+        """
+        Parameters
+        ----------
+        dirname : Path
+            Path of the directory containing the Enlil model output
+        """
+        self._data_dir = dirname
+        fname = str(self._data_dir / "pv-data-3d.nc")
+        self.data = pvs.NetCDFReader(registrationName="enlil-data", FileName=[fname])
+        self.data.Dimensions = "(longitude, latitude, radius)"
+
+        # Use properties for the variable mapping
+        var_map = {
+            "velocity": "Vr",
+            "density": "Density",
+            "pressure": "Pressure",
+            "temperature": "T",
+            "b": "Br",
+            "bx": "Bx",
+            "by": "By",
+            "bz": "Bz",
+            "dp": "DP",
+        }
+        for key, val in var_map.items():
+            setattr(self, key, val)


### PR DESCRIPTION
This abstracts out the different models into their own classes and does the variable renaming via those classes, so everything can be consistent within the app, even when modelers label their variables differently.

Right now, you should be able to use this with Enlil data and nothing will have changed. Otherwise if you download the large EUHFORIA dataset and load it by uncommenting out the `models.Euhforia` call, then you should get Euhforia data displayed in the visualizer.